### PR TITLE
[#52577011] Fix the bug that a complex deal having duplicated linking ac...

### DIFF
--- a/spec/models/deal/linking_spec.rb
+++ b/spec/models/deal/linking_spec.rb
@@ -203,6 +203,20 @@ describe "Deal Linking" do
 
     end
 
+    describe "同じユーザーの同じ口座への記入が複数ある複数明細" do
+      let(:deal) do
+        # taro_hanako から taro_food へ ×２
+        new_complex_deal(7, 15, [[:taro_food, 500], [:taro_food, 800]], [[:taro_hanako, -500], [:taro_hanako, -800]])
+      end
+
+      describe "valid?" do
+        it { deal.valid?.should be_true }
+      end
+
+      describe "save" do
+        it { deal.save.should be_true }
+      end
+    end
 
   end
 


### PR DESCRIPTION
...count entry can not be saved.

複数明細に複数の同じ連携口座への記入が含まれている場合（相手側でも複数明細が作られる場合）に、Entryのline_numberが重複する（全部0なので）という例外になっていた件を修正。登録時には採番するようにした。
