### PR TITLE
[#52577079] Fix the bug that summary is not set to complex linked deal.

### DIFF
--- a/app/models/deal/general.rb
+++ b/app/models/deal/general.rb
@@ -185,10 +185,11 @@ class Deal::General < Deal::Base
 
   # 指定された他ユーザーに関係する entry を抽出してハッシュで返す
   # 口座情報は、こちらで想定している相手口座情報を入れる
+  # モードに関わらず、Entryごとのサマリーも含む
   def entries_hash_for(remote_user_id)
     related_entries(remote_user_id).map do |e|
       ex_account_id = e.account.link.try(:target_ex_account_id) || e.account.link_requests.detect{|lr| lr.sender_id == remote_user_id}.sender_ex_account_id
-      {:id => e.id, :ex_account_id => ex_account_id, :amount => e.amount}
+      {:id => e.id, :ex_account_id => ex_account_id, :amount => e.amount, :summary => e.summary}
     end
   end
 
@@ -267,7 +268,7 @@ class Deal::General < Deal::Base
     updated.each do |receiver_id|
       receiver = User.find(receiver_id)
       # このユーザーに関連する entry 情報（id, 口座, 金額のハッシュ）を送る
-      linked_entries = receiver.link_deal_for(user_id, id, entries_hash_for(receiver_id), summary, date)
+      linked_entries = receiver.link_deal_for(user_id, id, entries_hash_for(receiver_id), summary_mode, summary, date)
 #      next unless linked_entries # false なら、こちらの変更は不要
       for entry_id, ex_info in linked_entries
         Entry::Base.update_all("linked_ex_entry_id = #{ex_info[:entry_id]}, linked_ex_deal_id = #{ex_info[:deal_id]}, linked_user_id = #{receiver.id}",  "id = #{entry_id}")

--- a/app/models/entry/general.rb
+++ b/app/models/entry/general.rb
@@ -22,7 +22,7 @@ class Entry::General < Entry::Base
     unless linked_account_entry
       # 自分側からリンクがきれてるのに相手に残っている場合は異常ケース。いったん相手とunlinkする
       receiver.unlink_deal_for(user_id, deal_id) if receiver.linked_deal_for(user_id, deal_id)
-      linked_entries = receiver.link_deal_for(user_id, deal_id, deal.entries_hash_for(receiver.id), deal.summary, date)
+      linked_entries = receiver.link_deal_for(user_id, deal_id, deal.entries_hash_for(receiver.id), deal.summary_mode, deal.summary, date)
       for entry_id, ex_info in linked_entries
         Entry::Base.update_all("linked_ex_entry_id = #{ex_info[:entry_id]}, linked_ex_deal_id = #{ex_info[:deal_id]}, linked_user_id = #{receiver.id}",  "id = #{entry_id}")
       end

--- a/spec/models/deal/linking_spec.rb
+++ b/spec/models/deal/linking_spec.rb
@@ -7,9 +7,11 @@ describe "Deal Linking" do
   fixtures :accounts, :account_links, :account_link_requests, :friend_requests, :friend_permissions, :users
   set_fixture_class  :accounts => Account::Base, :deals => Deal::Base
 
+  let(:taro) { users(:taro) }
+  let(:hanako) { users(:hanako) }
   before do
-    @taro = users(:taro)
-    @hanako = users(:hanako)
+    @taro = taro # TODO: @taro は削除したい
+    @hanako = hanako # TODO: @hanako は削除したい
     @home = users(:home)
     raise "@taroと@hanakoは友達" unless @taro.friend?(@hanako) && @hanako.friend?(@taro)
     raise "@taroと@homeは友達" unless @taro.friend?(@home) && @home.friend?(@taro)
@@ -117,6 +119,67 @@ describe "Deal Linking" do
       home_income_from_two_entry.linked_ex_deal_id.should == @taro_deal.id
       home_income_from_two_entry.linked_user_id.should == @taro.id
       home_income_from_two_entry.linked_ex_entry_confirmed.should be_true
+    end
+
+    context "サマリー分割モードで記入された連携Entryを１つ含む複数明細" do
+      let(:deal) {
+        new_complex_deal(7, 15, [[:taro_food, 800, 'ラーメン'], [:taro_food, 500, '菓子']], [[:taro_hanako, -800, '[太郎]ラーメン'], [:taro_hanako, -500, '[太郎]菓子']])
+      }
+
+      describe "valid?" do
+        it { deal.valid?.should be_true }
+      end
+
+      describe "save (create)" do
+        it "登録が成功し、正しいサマリーが連携記入に含まれる" do
+          deal.save.should be_true
+          linked_deal = hanako.linked_deal_for(taro.id, deal.id)
+          linked_deal.should_not be_nil
+          # 花子側の借方に連携が入る
+          linked_deal.debtor_entries.map(&:summary).should == ['[太郎]ラーメン', '[太郎]菓子']
+        end
+      end
+
+      describe "save (update)" do
+        before do
+          deal.save!
+        end
+
+        context "一度保存して連携取引ができたあと、splitモードのまま、一部のサマリーを変えたとき" do
+          before do
+            deal.attributes = {
+              :debtor_entries_attributes => deal.debtor_entries.map{|e| {:account_id => e.account_id, :amount => e.amount, :id => e.id, :line_number => e.line_number, :summary => e.summary}},
+              :creditor_entries_attributes => deal.creditor_entries.map{|e| {:account_id => e.account_id, :amount => e.amount, :id => e.id, :line_number => e.line_number, :summary => e.summary == '[太郎]ラーメン' ? '[太郎]味噌ラーメン' : e.summary}}
+            }
+          end
+          it "更新が成功し、変更後のサマリーが連携記入に含まれる" do
+            deal.save.should be_true
+            linked_deal = hanako.linked_deal_for(taro.id, deal.id)
+            linked_deal.should_not be_nil
+            # 花子側の借方に連携が入る
+            linked_deal.debtor_entries.map(&:summary).should == ['[太郎]味噌ラーメン', '[太郎]菓子']
+          end
+        end
+
+        context "一度保存して連携取引ができたあと、unifyモードにしてサマリーを変えたとき" do
+          before do
+            deal.attributes = {
+              :summary_mode => 'unify',
+              :summary => 'ラーメンと菓子',
+              :debtor_entries_attributes => deal.debtor_entries.map{|e| {:account_id => e.account_id, :amount => e.amount, :id => e.id, :line_number => e.line_number}},
+              :creditor_entries_attributes => deal.creditor_entries.map{|e| {:account_id => e.account_id, :amount => e.amount, :id => e.id, :line_number => e.line_number}}
+            }
+          end
+          it "更新が成功し、変更後のサマリーが連携記入に含まれる" do
+            deal.save.should be_true
+            linked_deal = hanako.linked_deal_for(taro.id, deal.id)
+            linked_deal.should_not be_nil
+            # 花子側の借方に連携が入る
+            linked_deal.debtor_entries.map(&:summary).should == ['ラーメンと菓子', 'ラーメンと菓子']
+            linked_deal.summary_unified?.should be_true
+          end
+        end
+      end
     end
 
     describe "両面取引" do


### PR DESCRIPTION
複数明細で、サマリーを個別に入れている場合に、サマリーが正しく連携先取引に入らない不具合を修正しました。
