### PR TITLE
精算開始年を遡れるようにした

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -356,7 +356,17 @@ class User < ApplicationRecord
     end
     [result, dates]
   end
-  
+
+  # 最古の記入のある年
+  def start_year
+    @start_year ||= entries.minimum(:date).year
+  end
+
+  # 最古の記入のある年、古すぎるときは100年前
+  def pragmatic_start_year
+    [start_year, Time.zone.now.year - 100].max
+  end
+
   protected
   # before filter 
   def encrypt_password

--- a/app/views/settlements/new.html.haml
+++ b/app/views/settlements/new.html.haml
@@ -22,9 +22,9 @@
         .col-xs-4
           = select_tag :account_id, options_for_select(@credit_accounts.map{|a| [a.name_with_asset_type, a.id]}, @account.id), class: 'form-control account_selector', data: {url_template: new_account_settlement_path(account_id: "_ACCOUNT_ID_")}
         .col-xs-8
-          = select_date(@start_date, :prefix => 'start_date', :use_month_numbers => true)
+          = select_date(@start_date, prefix: 'start_date', use_month_numbers: true, start_year: current_user.pragmatic_start_year, end_year: Time.zone.now.year+1)
           ～
-          = select_date(@end_date, :prefix => 'end_date', :use_month_numbers => true)
+          = select_date(@end_date, prefix: 'end_date', use_month_numbers: true, start_year: current_user.pragmatic_start_year, end_year: Time.zone.now.year+1)
 
     - unless @settlement.errors.empty?
       %div= error_messages_for 'settlement'


### PR DESCRIPTION
# 概要

https://github.com/everyleaf/kozuchi/issues/65

５年以上古いデータの精算が作れなくて困ったのでデータのある範囲で作れるように修正。リストボックスで使うので選択肢が多くならないよう100年前までに制限した。未来は記入があってもそんなに要らないはずなので翌年までにしておいた。
