### PR TITLE
記入画面からのアカウント切り替えで記入画面にいけるようにした

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,6 +13,8 @@ module ApplicationHelper
   def single_login_destination
     if controller_name == 'deals' && action_name == 'monthly'
       :deals
+    elsif controller_name == 'deals' && action_name == 'new'
+      :new_deal
     else
       nil
     end


### PR DESCRIPTION
# 概要
https://github.com/everyleaf/kozuchi/issues/44

記入画面の場合にホームにいって待ち時間がイライラしたので記入画面に行けるようにした。
ついでに、古いページからのアカウントきりかえなどで例外画面が出ていたのを出ないようにした。