### PR TITLE
古い精算も概況で見られるようにする

### DIFF
--- a/app/controllers/settlements_controller.rb
+++ b/app/controllers/settlements_controller.rb
@@ -72,6 +72,7 @@ class SettlementsController < ApplicationController
     end
   end
 
+  # 概況
   # TDOO: current_account まわりを強引に消したので見直す
   def index
     prepare_for_summary_months
@@ -183,7 +184,7 @@ class SettlementsController < ApplicationController
     end
   end
 
-  def prepare_for_summary_months(past = 7, future = 2)
+  def prepare_for_summary_months(past = 9, future = 1)
     # 月サマリー用の月情報
     @months = []
     date = start_date = Time.zone.today.beginning_of_month << past
@@ -214,4 +215,3 @@ class SettlementsController < ApplicationController
   end
   
 end
- 

--- a/app/controllers/settlements_controller.rb
+++ b/app/controllers/settlements_controller.rb
@@ -91,8 +91,6 @@ class SettlementsController < ApplicationController
 
   # ある勘定の精算一覧を提供する
   def account_settlements
-    prepare_for_summary_months(5, 1)
-
     self.menu = "#{@account.name}の精算一覧"
 
     @settlements = current_user.settlements.on(@account).includes(:result_entry => :deal).order('deals.date DESC, settlements.id DESC')

--- a/app/views/settlements/_summary.html.haml
+++ b/app/views/settlements/_summary.html.haml
@@ -14,9 +14,8 @@
     %tr
       - if with_account_headers
         %th
-          = account.name
+          = link_to account.name, account_settlements_path(account_id: account.id)
           .pull-right
-            = link_to '一覧', account_settlements_path(account_id: account.id), class: %w(btn btn-default btn-sm)
             = link_to '作成', new_account_settlement_path(account_id: account.id), class: %w(btn btn-default btn-sm)
       - @months.each do |monthly_date|
         %td.settlement

--- a/app/views/settlements/_summary.html.haml
+++ b/app/views/settlements/_summary.html.haml
@@ -1,29 +1,25 @@
-- with_account_headers ||= false
 %table.book.settlements_summary
   %tr
-    - if with_account_headers
-      %th
+    %th
     - @years.each do |year, months|
       %th{colspan: months.size}= "#{year}年"
   %tr
-    - if with_account_headers
-      %th
-        .pull-right
-          - if @previous_target_date
-            = link_to '前へ', settlements_summary_path(@previous_target_date.year, @previous_target_date.month), class: %w(btn btn-info btn-sm)
+    %th
+      .pull-right
+        - if @previous_target_date
+          = link_to '前へ', settlements_summary_path(@previous_target_date.year, @previous_target_date.month), class: %w(btn btn-info btn-sm)
     - @months.each do |monthly_date|
       %th= "#{monthly_date.month}月"
-    - if with_account_headers && @next_target_date
+    - if @next_target_date
       %th
         .pull-left
           = link_to '後へ', settlements_summary_path(@next_target_date.year, @next_target_date.month), class: %w(btn btn-info btn-sm)
   - @summaries.each do |account, account_settlements|
     %tr
-      - if with_account_headers
-        %th
-          = link_to account.name, account_settlements_path(account_id: account.id)
-          .pull-right
-            = link_to '作成', new_account_settlement_path(account_id: account.id), class: %w(btn btn-default btn-sm)
+      %th
+        = link_to account.name, account_settlements_path(account_id: account.id)
+        .pull-right
+          = link_to '作成', new_account_settlement_path(account_id: account.id), class: %w(btn btn-default btn-sm)
       - @months.each do |monthly_date|
         %td.settlement
           - if account_settlements.present?
@@ -31,5 +27,5 @@
               %div= link_to number_with_delimiter(s.amount), settlement_path(s.id)
           - else
             &nbsp;
-      - if with_account_headers && @next_target_date
+      - if @next_target_date
         %th{width: "20px;"}

--- a/app/views/settlements/_summary.html.haml
+++ b/app/views/settlements/_summary.html.haml
@@ -8,8 +8,15 @@
   %tr
     - if with_account_headers
       %th
+        .pull-right
+          - if @previous_target_date
+            = link_to '前へ', settlements_summary_path(@previous_target_date.year, @previous_target_date.month), class: %w(btn btn-info btn-sm)
     - @months.each do |monthly_date|
       %th= "#{monthly_date.month}月"
+    - if with_account_headers && @next_target_date
+      %th
+        .pull-left
+          = link_to '後へ', settlements_summary_path(@next_target_date.year, @next_target_date.month), class: %w(btn btn-info btn-sm)
   - @summaries.each do |account, account_settlements|
     %tr
       - if with_account_headers
@@ -24,3 +31,5 @@
               %div= link_to number_with_delimiter(s.amount), settlement_path(s.id)
           - else
             &nbsp;
+      - if with_account_headers && @next_target_date
+        %th{width: "20px;"}

--- a/app/views/settlements/account_settlements.html.haml
+++ b/app/views/settlements/account_settlements.html.haml
@@ -1,7 +1,8 @@
 #settlements_right
+  = link_to "概況", settlements_path, class:  %w(btn btn-default)
+  %hr
   = link_to "新しい精算", new_account_settlement_path(account_id: @account.id), class: %w(btn btn-primary)
   = link_to @account.name, monthly_account_deals_path(account_id: @account.id, year: Time.zone.today.year, month: Time.zone.today.month), class: %w(btn btn-default)
-  = link_to "概況", settlements_path, class:  %w(btn btn-default)
 
 #settlements_main
   #settlements
@@ -13,7 +14,6 @@
           #account_options
             = select_tag :account_id, options_for_select(@credit_accounts.map{|a| [a.name_with_asset_type, a.id]}, @account.try(:id).to_s), class: %w(switcher form-control), data: {url_template: account_settlements_path(account_id: "_SWITCHER_VALUE_")}
       .col-xs-8
-        = render partial: 'summary'
 
     %h3 一覧
     - if @settlements.empty?

--- a/app/views/settlements/index.html.haml
+++ b/app/views/settlements/index.html.haml
@@ -1,4 +1,4 @@
 - if flash[:notice]
   %div= flash[:notice]
 
-= render partial: 'summary', locals: {with_account_headers: true}
+= render partial: 'summary'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -100,6 +100,7 @@ Kozuchi::Application.routes.draw do
         resources :settlements, only: [:new, :create]
       end
     end
+    get 'settlements/summary/:year/:month', action: :index, as: :settlements_summary
     resources :settlements, :only => [:index, :show, :destroy] do
       member do
         get 'print_form'


### PR DESCRIPTION
# 概要
https://github.com/everyleaf/kozuchi/issues/74

ここで見られないとやる気が出ないので出すようにした。

口座ごとの一覧は基本的に時間軸を縦で見るので、横型を併置するのは混乱するしコードも散らかるのでやめる。
