### PR TITLE
金額の前後に半角スペースを含んでいても記入できるようにする

### DIFF
--- a/app/models/entry/base.rb
+++ b/app/models/entry/base.rb
@@ -68,9 +68,9 @@ class Entry::Base < ApplicationRecord
     !!balance
   end
 
-  # StringならString のまま , はとる
+  # StringならString のまま 前後のスペースを削除して , をとる
   def self.parse_amount(value)
-    value.kind_of?(String) ? value.gsub(/,/, '') : value
+    value.kind_of?(String) ? value.strip.gsub(/,/, '') : value
   end
 
   def amount=(a)

--- a/lib/entry.rb
+++ b/lib/entry.rb
@@ -13,12 +13,12 @@ module Entry
   end
 
   def reversed_amount=(ra)
-    # まずそのまま入れて、コンパ入りの場合のパーズと、before_type_cast の保存をする
+    # まずそのまま入れて、コンマ入りの場合のパーズと、before_type_cast の保存をする
     # これによりフォーマット不正の検証がそのまま動く
     self.amount = ra
     @reversed_amount_before_type_cast = amount_before_type_cast
-    # 数値として意味があり、文字列でないか、正しい文字列である場合は符号逆転の値を入れ直す
-    self.amount *= -1 if ra.to_i != 0 && (!ra.kind_of?(String) || ra =~ /^-?([0-9]|,)*$/)
+    # ActiveRecord によりキャストされた数値の符号を逆転する
+    self.amount *= -1 unless amount.nil?
     # 正しい値であった場合は、amount_before_type_cast は変化する
   end
 
@@ -26,7 +26,7 @@ module Entry
     self.amount.blank? ? self.amount : self.amount.to_i * -1
   end
 
-  # 検証エラー時、フォーマット不正の状態を画面を残すため
+  # 検証エラー時、フォーマット不正の状態を画面に残すため
   def reversed_amount_before_type_cast
     @reversed_amount_before_type_cast || reversed_amount
   end

--- a/spec/features/deals_js_spec.rb
+++ b/spec/features/deals_js_spec.rb
@@ -171,14 +171,14 @@ describe DealsController, js: true, type: :feature do
               expect(page).to have_content('金額は数値で入力してください。')
             end
           end
-        end
 
-        context "金額の前後に半角スペースが含まれるとき" do
-          let(:amount) { ' 210 ' }
-          it "登録できる" do
-            expect(flash_notice).to have_content('追加しました。')
-            expect(current_hash).to eq "recent"
-            expect(page).to have_content('朝食のおにぎり')
+          context "金額の前後に半角スペースが含まれるとき" do
+            let(:amount) { ' 210 ' }
+            it "登録できる" do
+              expect(flash_notice).to have_content('追加しました。')
+              expect(current_hash).to eq "recent"
+              expect(page).to have_content('朝食のおにぎり')
+            end
           end
         end
       end

--- a/spec/features/deals_js_spec.rb
+++ b/spec/features/deals_js_spec.rb
@@ -172,6 +172,15 @@ describe DealsController, js: true, type: :feature do
             end
           end
         end
+
+        context "金額の前後に半角スペースが含まれるとき" do
+          let(:amount) { ' 210 ' }
+          it "登録できる" do
+            expect(flash_notice).to have_content('追加しました。')
+            expect(current_hash).to eq "recent"
+            expect(page).to have_content('朝食のおにぎり')
+          end
+        end
       end
 
       describe "通常明細のサジェッション" do
@@ -342,9 +351,9 @@ describe DealsController, js: true, type: :feature do
             before do
               find('a.entry_summary').click # unifyモードにする
               fill_in 'deal_summary', :with => '買い物'
-              fill_in 'deal_creditor_entries_attributes_0_reversed_amount', :with => amount
+              fill_in 'deal_creditor_entries_attributes_0_reversed_amount', :with => reversed_amount
               select '現金', :from => 'deal_creditor_entries_attributes_0_account_id'
-              fill_in 'deal_debtor_entries_attributes_0_amount', :with => '800'
+              fill_in 'deal_debtor_entries_attributes_0_amount', :with => amount
               select '食費', :from => 'deal_debtor_entries_attributes_0_account_id'
               fill_in 'deal_debtor_entries_attributes_1_amount', :with => '200'
               select '雑費', :from => 'deal_debtor_entries_attributes_1_account_id'
@@ -352,7 +361,8 @@ describe DealsController, js: true, type: :feature do
             end
 
             context "金額が正しいとき" do
-              let(:amount) { '1000' }
+              let(:reversed_amount) { '1000' }
+              let(:amount) { '800' }
               it "登録でき、明細が一覧に表示される" do
                 expect(flash_notice).to have_content('追加しました。')
                 expect(page).to have_content '買い物'
@@ -363,11 +373,34 @@ describe DealsController, js: true, type: :feature do
               end
             end
 
-            context "金額がアルファベットのとき" do
+            context "貸方金額がアルファベットのとき" do
+              let(:reversed_amount) { 'abc' }
+              let(:amount) { '800' }
+              it "エラーが表示される" do
+                expect(page).to have_content 'エラーが発生しました。'
+                expect(page).to have_content '金額は数値で入力してください。'
+              end
+            end
+
+            context "借方金額がアルファベットのとき" do
+              let(:reversed_amount) { '1000' }
               let(:amount) { 'abc' }
               it "エラーが表示される" do
                 expect(page).to have_content 'エラーが発生しました。'
                 expect(page).to have_content '金額は数値で入力してください。'
+              end
+            end
+
+            context "金額の前後に半角スペースが含まれるとき" do
+              let(:reversed_amount) { ' 1000 ' }
+              let(:amount) { '    800' }
+              it "登録でき、明細が一覧に表示される" do
+                expect(flash_notice).to have_content('追加しました。')
+                expect(page).to have_content '買い物'
+                expect(page).to have_content '1,000'
+                expect(page).to have_content '800'
+                expect(page).to have_content '200'
+                expect(current_hash).to eq "recent"
               end
             end
           end
@@ -446,6 +479,16 @@ describe DealsController, js: true, type: :feature do
               expect(page).to have_content("残高は数値で入力してください。")
             end
           end
+
+          context "金額の前後に半角スペースが含まれるとき" do
+            let(:amount) { '   1003' }
+            it "登録できる" do
+              expect(flash_notice).to have_content("追加しました。")
+              expect(page).to have_content("残高確認")
+              expect(page).to have_content("1,003")
+            end
+          end
+
         end
       end
     end

--- a/spec/models/entry/general_spec.rb
+++ b/spec/models/entry/general_spec.rb
@@ -69,8 +69,8 @@ describe Entry::General do
       before do
         entry.reversed_amount = '1.10'
       end
-      it "amountは1になる" do
-        entry.amount.should == 1
+      it "amountは-1になる" do # -1.10 を入れるため
+        entry.amount.should == -1
       end
       it "reversed_amount_before_type_castは'1.10'になる" do
         entry.reversed_amount_before_type_cast.should == '1.10'


### PR DESCRIPTION
コピペのときスペースが含まれるケースがあるのでスペースがついていても記入できるように修正。

https://github.com/everyleaf/kozuchi/issues/85