### PR TITLE
金額なしボタンの改良

### DIFF
--- a/app/views/deal_suggestions/_patterns.html.haml
+++ b/app/views/deal_suggestions/_patterns.html.haml
@@ -11,6 +11,10 @@
           %td
             .clickable_text{onClick: on_click}
               %div{class: "#{pattern.css_class}"}= pattern.caption
+          %td
+            .clickable_text{onClick: on_click_without_amount, style: "margin-left: 4px; margin-right; 4px;"}
+              %div{class: "#{pattern.css_class}"}
+                ¥__&nbsp;
           %td{style: "text-align: right;"}= number_with_delimiter(pattern.debtor_amount)
           - if current_user.bookkeeping_style?
             %td= "(借) #{pattern.debtor_account_name}"
@@ -19,7 +23,3 @@
             %td= "[#{pattern.creditor_account_name}]"
             %td= " → "
             %td= "[#{pattern.debtor_account_name}]"
-          %td
-            .clickable_text{onClick: on_click_without_amount, style: "margin-left: 2px;"}
-              %div{class: "#{pattern.css_class}"}
-                金額なし

--- a/app/views/deals/_monthly_js.html.erb
+++ b/app/views/deals/_monthly_js.html.erb
@@ -19,8 +19,6 @@
         jQuery('#deal_forms').load('<%= url_for(:action => 'new_complex_deal', :controller => 'deals') %>', params, function() {
           displaySuggestionsForComplex()
         })
-
-        $('#deal_forms input.amount').focus();
     }
     function fillForComplexDeal(id, type, with_amount) {
         if($('#notice')){ $('#notice').hide();}
@@ -31,8 +29,6 @@
         jQuery('#deal_forms').load('<%= url_for(:action => 'new_complex_deal', :controller => 'deals') %>', params, function() {
           displaySuggestionsForComplex();
         })
-
-        $('#deal_forms input.amount').focus();
     }
     function displaySuggestionsForComplex() {
         jQuery('#patterns').load('<%= deal_suggestions_path(:from => 'complex_deal') %>', 'keyword=' + encodeURIComponent($('#deal_summary').val()))

--- a/app/views/deals/_monthly_js.html.erb
+++ b/app/views/deals/_monthly_js.html.erb
@@ -4,6 +4,8 @@
         selectList('#deal_creditor_entries_attributes_0_account_id', minus_account_id);
         selectList('#deal_debtor_entries_attributes_0_account_id', plus_account_id);
         $('#deal_summary').val(summary);
+
+        $('#deal_forms input.amount').focus();
     }
     function selectList(name, value) {
         $(name).val(value);
@@ -17,6 +19,8 @@
         jQuery('#deal_forms').load('<%= url_for(:action => 'new_complex_deal', :controller => 'deals') %>', params, function() {
           displaySuggestionsForComplex()
         })
+
+        $('#deal_forms input.amount').focus();
     }
     function fillForComplexDeal(id, type, with_amount) {
         if($('#notice')){ $('#notice').hide();}
@@ -27,6 +31,8 @@
         jQuery('#deal_forms').load('<%= url_for(:action => 'new_complex_deal', :controller => 'deals') %>', params, function() {
           displaySuggestionsForComplex();
         })
+
+        $('#deal_forms input.amount').focus();
     }
     function displaySuggestionsForComplex() {
         jQuery('#patterns').load('<%= deal_suggestions_path(:from => 'complex_deal') %>', 'keyword=' + encodeURIComponent($('#deal_summary').val()))


### PR DESCRIPTION
## issues
* https://github.com/everyleaf/kozuchi/issues/86
* https://github.com/everyleaf/kozuchi/issues/71
## 内容
* ¥__ にして、左側にもっていった
* シンプル明細のときは、金額あり・なしに関わらずdealデータロード後に金額にフォーカスされるようにした