### PR TITLE
口座選択状態での残高記入で口座を選んだ状態にする

### DIFF
--- a/app/assets/javascripts/deals.js.coffee
+++ b/app/assets/javascripts/deals.js.coffee
@@ -133,8 +133,8 @@ $ ->
         resultUrl = null
         resultUrlWithHash = null
         if result.redirect_to
-          resultUrl = result.redirect_to
-          resultUrlWithHash = resultUrl
+          resultUrlWithHash = result.redirect_to
+          resultUrl = resultUrlWithHash.split('#')[0]
         else
           if dealHasAccountId(result.deal, $('#deal_form_option').data("condition-account-id")) # 遷移先に条件がついていて適合していればそちらのURLにする
             resultUrl = $('#deal_form_option').data("condition-match-url").replace(/_YEAR_/, result.year).replace(/_MONTH_/, result.month)

--- a/app/models/account/asset.rb
+++ b/app/models/account/asset.rb
@@ -18,6 +18,10 @@ class Account::Asset < Account::Base
     where("accounts.asset_kind in (?)", kinds)
   }
 
+  def asset?
+    true
+  end
+
   def self.has_kind?
     true
   end

--- a/app/models/account/base.rb
+++ b/app/models/account/base.rb
@@ -14,6 +14,18 @@ class Account::Base < ApplicationRecord
 
   has_many :result_settlements, through: :entries
 
+  def asset?
+    false
+  end
+
+  def expense?
+    false
+  end
+
+  def income?
+    false
+  end
+
   def self.has_kind?
     false
   end

--- a/app/models/account/expense.rb
+++ b/app/models/account/expense.rb
@@ -5,6 +5,10 @@ class Account::Expense < Account::Base
   short_name '支出'
   connectable_type Account::Income
 
+  def expense?
+    true
+  end
+
   # TODO: Rails 2.2
   def self.human_name
     '費目'

--- a/app/models/account/income.rb
+++ b/app/models/account/income.rb
@@ -5,6 +5,10 @@ class Account::Income < Account::Base
   short_name '収入'
   connectable_type Account::Expense
 
+  def income?
+    true
+  end
+
   # TODO: Rails 2.2 で国際化対応
   def self.human_name
     '収入内訳'

--- a/app/views/deals/_balance_deal_form_contents.html.haml
+++ b/app/views/deals/_balance_deal_form_contents.html.haml
@@ -1,5 +1,5 @@
 .deal_fields
-  = f.select :account_id, options_from_collection_for_select(current_user.assets, :id, :name, @deal.account_id), tabindex: 13, class: %w(account_selector)
+  = f.select :account_id, options_from_collection_for_select((@account && @account.asset?) ? [@account] : current_user.assets, :id, :name, @deal.account_id), tabindex: 13, class: %w(account_selector)
   #money_counting
     - [[:man, :gosen, :nisen, :sen, :gohyaku],[:hyaku, :gojyu, :jyu, :go, :ichi]].each do |units|
       - units.each do |name|


### PR DESCRIPTION
# Overview
口座選択状態での残高記入で口座を選んだ状態にする

# Related Issues
* https://github.com/everyleaf/kozuchi/issues/89

# Details
ついでに残高記入時に アンカー付きのURLとついていないURLを比較して誤判定してリロードされない不具合を修正