### PR TITLE
残高フォームで口座が絞り込まれないことの修正

### DIFF
--- a/app/controllers/deals_controller.rb
+++ b/app/controllers/deals_controller.rb
@@ -8,7 +8,8 @@ class DealsController < ApplicationController
   before_action :check_account
   before_action :find_deal, :only => [:edit, :load_deal_pattern_into_edit, :update, :confirm, :destroy, :show]
   before_action :find_new_or_existing_deal, :only => [:create_entry]
-  before_action :find_account_if_specified, only: [:index, :monthly]
+  before_action :find_account_if_specified, only: [:index, :monthly, :new_general_deal, :new_complex_deal, :new_balance_deal, :create_general_deal, :create_complex_deal, :create_balance_deal]
+  # NOTE: create_xxx_deal では @account はアクションでは使わないが、例えば残高記入で記入エラーが合った際の render で new の時点と画面が変わる恐れがあるため、元画面にあれば ajax でも伝わってくるようにしておく
 
   # 単数記入タブエリアの表示 (Ajax)
   def new_general_deal

--- a/app/views/deals/_balance_deal_form.html.erb
+++ b/app/views/deals/_balance_deal_form.html.erb
@@ -1,5 +1,5 @@
 <%= deal_form '残高',
-              :url => balance_deals_path do |f| %>
+              :url => {action: :create_balance_deal} do |f| %>
   <%= render :partial => 'balance_deal_form_contents', :locals => {:f => f} %>
 <% end %>
 <%= error_messages_for :deal %>

--- a/app/views/deals/_complex_deal_form.html.erb
+++ b/app/views/deals/_complex_deal_form.html.erb
@@ -1,6 +1,6 @@
 <% @deal.modify_errors_for_complex_form %>
 <%= deal_form '明細(複数)',
-              :url => complex_deals_path do |f| %>
+              :url => {action: :create_complex_deal} do |f| %>
   <%= render :partial => 'complex_deal_form_contents', :locals => {:f => f} %>
 <% end %>
 <%= error_messages_for :deal %>

--- a/app/views/deals/_general_deal_form.html.haml
+++ b/app/views/deals/_general_deal_form.html.haml
@@ -1,4 +1,4 @@
 - @deal.modify_errors_for_simple_form
-= deal_form '明細', url: general_deals_path do |f|
+= deal_form '明細', url: {action: :create_general_deal} do |f|
   = render partial: 'general_deal_form_contents', locals: {f: f, pattern_update_area: '#deal_forms'}
 = error_messages_for :deal

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,6 +76,8 @@ Kozuchi::Application.routes.draw do
     ['general', 'balance', 'complex'].each do |t|
       post "#{t}_deals", :action => "create_#{t}_deal", :as => :"#{t}_deals"
       get "#{t}_deals/new", :action => "new_#{t}_deal", :as => :"new_#{t}_deal"
+      post "accounts/:account_id/#{t}_deals", :action => "create_#{t}_deal", :as => :"account_#{t}_deals"
+      get "accounts/:account_id/#{t}_deals/new", :action => "new_#{t}_deal", :as => :"new_account_#{t}_deal"
     end
 
     get 'deals/:year/:month/days', :as => :monthly_deal_days, :action => 'day_navigator'


### PR DESCRIPTION
# Overview
Ajax で記入欄を更新する際に口座絞り込み状態かどうかの情報が失われていたので修正
エラーを考慮して登録時まで引き継ぐようにした

# Related Issues
https://github.com/everyleaf/kozuchi/issues/123

# Details
