### PR TITLE
Dealをjoinせずに計算しやすくした

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ doc/app/*
 config/database.yml
 config/mongrel_cluster.yml
 config/initializers/hosting.rb
-db/schema.rb
 db/development_structure.sql
 coverage/*
 .DS_Store

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -19,7 +19,8 @@ class HomeController < ApplicationController
   end
   
   def prepare_expenses_summary
-    expenses, expenses_dates = @user.recent(6) {|user, d| user.expenses_summary(d.year, d.month)}
+    # expenses, expenses_dates = @user.recent(6) {|user, d| user.expenses_summary(d.year, d.month)}
+    expenses, expenses_dates = @user.recent(6) {|user, d| user.accounts.expense_sum(d.beginning_of_month, d.end_of_month+1)}
     expenses = [expenses]
     @expenses_summary = LineGraph.new(expenses, ["支出合計"])
     @months_for_expenses = ["月"].concat(expenses_dates.map{|d| "#{d.month}月"})

--- a/app/models/account/base.rb
+++ b/app/models/account/base.rb
@@ -38,11 +38,12 @@ class Account::Base < ApplicationRecord
 
   # TODO: with_joined_scope 相当
   scope :join_entries_and_deals, -> { joins("inner join account_entries on accounts.id = account_entries.account_id inner join deals on account_entries.deal_id = deals.id") }
+  scope :join_confirmed_entries, -> { joins(sanitize_sql_array(["INNER JOIN account_entries on accounts.id = account_entries.account_id AND account_entries.confirmed = ?", TRUE]))  }
 
   # flow_sum を関連起点で無くした版
   # 指定した期間における指定した口座のフロー合計を得る。
   def self.total_flow(start_date, end_date)
-    join_entries_and_deals.merge(Deal::Base.confirmed).merge(Entry::Base.in_a_time_between(start_date, end_date).not_initial_balance).sum("account_entries.amount").to_i
+    join_confirmed_entries.merge(Entry::Base.in_a_time_between(start_date, end_date).not_initial_balance).sum("account_entries.amount").to_i
   end
 
   def total_flow(start_date, end_date)
@@ -205,9 +206,10 @@ class Account::Base < ApplicationRecord
 
   # 口座別計算メソッド
 
+  # NOTE: 最新版...^^;
   # TODO: 資産合計はこれを使ったほうがはやそう
   def self.balance_before_date(date)
-    join_entries_and_deals.merge(Deal::Base.confirmed).merge(Entry::Base.before_or_initial(date)).sum(:amount) || 0
+    join_confirmed_entries.merge(Entry::Base.before_or_initial(date)).sum(:amount) || 0
   end
 
   # おそらく balance_before とほぼ同じ

--- a/app/models/account/base.rb
+++ b/app/models/account/base.rb
@@ -13,8 +13,14 @@ class Account::Base < ApplicationRecord
 
   has_many :result_settlements, through: :entries
 
-  scope :active,   -> { where(active: true) }
-  scope :inactive, -> { where(active: false) }
+  scope :active,     -> { where(active: true) }
+  scope :inactive,   -> { where(active: false) }
+
+  scope :expense,           -> { where(type: "Account::Expense") }
+
+  # TODO: with_joined_scope 相当
+  scope :join_entries_and_deals, -> { joins("inner join account_entries on accounts.id = account_entries.account_id inner join deals on account_entries.deal_id = deals.id") }
+  scope :join_confirmed_entries, -> { joins(sanitize_sql_array(["INNER JOIN account_entries on accounts.id = account_entries.account_id AND account_entries.confirmed = ?", TRUE])) }
 
   def asset?
     false
@@ -36,12 +42,8 @@ class Account::Base < ApplicationRecord
     false
   end
 
-  # TODO: with_joined_scope 相当
-  scope :join_entries_and_deals, -> { joins("inner join account_entries on accounts.id = account_entries.account_id inner join deals on account_entries.deal_id = deals.id") }
-  scope :join_confirmed_entries, -> { joins(sanitize_sql_array(["INNER JOIN account_entries on accounts.id = account_entries.account_id AND account_entries.confirmed = ?", TRUE]))  }
-
   # flow_sum を関連起点で無くした版
-  # 指定した期間における指定した口座のフロー合計を得る。
+  # 指定した期間における指定した口座のフロー合計を得る。end_date は exclusive なので注意
   def self.total_flow(start_date, end_date)
     join_confirmed_entries.merge(Entry::Base.in_a_time_between(start_date, end_date).not_initial_balance).sum("account_entries.amount").to_i
   end

--- a/app/models/deal/balance.rb
+++ b/app/models/deal/balance.rb
@@ -30,6 +30,7 @@ class Deal::Balance < Deal::Base
     entry.user_id = user_id
     entry.date = date
     entry.daily_seq = daily_seq
+    entry.confirmed = confirmed
     entry
   end
 
@@ -88,6 +89,7 @@ class Deal::Balance < Deal::Base
     entry.date = date
     raise "no daily_seq" unless daily_seq
     entry.daily_seq = daily_seq
+    entry.confirmed = confirmed
   end
 
   def cache_account_id

--- a/app/models/deal/general.rb
+++ b/app/models/deal/general.rb
@@ -204,6 +204,7 @@ class Deal::General < Deal::Base
     super
     entry.date = date
     entry.daily_seq = daily_seq
+    entry.confirmed = confirmed
     entry
   end
 

--- a/app/models/entry/base.rb
+++ b/app/models/entry/base.rb
@@ -153,6 +153,7 @@ class Entry::Base < ApplicationRecord
       self.user_id = deal.user_id
       self.date = deal.date
       self.daily_seq = deal.daily_seq
+      self.confirmed = deal.confirmed
     end
     raise "no user_id" unless self.user_id
     raise "no date" unless self.date

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,8 +66,14 @@ class User < ApplicationRecord
     end
 
     # 指定した期間における支出口座のフロー合計を得る。支出の不明金も含める。
+    # end_date は exclusive
+    # NOTE: 不明金は正負逆転するとか、正負をそれぞれよせるかまとめてよせるかなどがあり、SQL一発でやるのは難しい
+    #   例えば 擬似的に views を作り、asset 勘定ごとに任意の方向で amount がとれるようにするといいのかもしれない
+    #   不明金を合体させて扱うのは総合的なところに限られるので、Accountクラスに引っ越す必要性は高くなさそう
     def expense_sum(start_date, end_date)
-      result = flow_sum(start_date, end_date, "accounts.type = 'Account::Expense'")
+#      TODO: 旧 flow_sum から 新 total_flow （accounts関連から accountsクラスメソッド系へ）へ移行中。参考のため残しておく
+#      result = flow_sum(start_date, end_date, "accounts.type = 'Account::Expense'")
+      result = expense.total_flow(start_date, end_date-1) # inclusive に修正...
       unknowns(start_date, end_date).delete_if{|a| a.unknown <= 0}.each{|a| result += a.unknown}
       result
     end

--- a/db/migrate/20170516212531_add_confirm_to_account_entries.rb
+++ b/db/migrate/20170516212531_add_confirm_to_account_entries.rb
@@ -1,12 +1,21 @@
+# ついでに index を増やしている
 class AddConfirmToAccountEntries < ActiveRecord::Migration[5.0]
   def up
     add_column :account_entries, :confirmed, :boolean, default: true, null: false
     execute "UPDATE account_entries INNER JOIN deals ON deals.id = account_entries.deal_id SET account_entries.confirmed = deals.confirmed"
-    add_index  :account_entries, [:date, :daily_seq]
-    add_index  :account_entries, :confirmed
-    add_index  :account_entries, :initial_balance
+    add_index     :account_entries, [:date, :daily_seq]
+    add_index     :account_entries, :confirmed
+    add_index     :account_entries, :initial_balance
+    change_column :account_entries, :type, :string, limit: 20
+    add_index     :account_entries, :type
+    change_column :accounts,        :type, :string, limit: 20
+    add_index     :accounts,        :type
   end
   def down
+    remove_index  :accounts,        :type
+    change_column :accounts,        :type, :text
+    remove_index  :account_entries, :type
+    change_column :account_entries, :type, :string
     remove_index  :account_entries, :initial_balance
     remove_index  :account_entries, [:date, :daily_seq]
     remove_index  :account_entries, :confirmed

--- a/db/migrate/20170516212531_add_confirm_to_account_entries.rb
+++ b/db/migrate/20170516212531_add_confirm_to_account_entries.rb
@@ -1,0 +1,15 @@
+class AddConfirmToAccountEntries < ActiveRecord::Migration[5.0]
+  def up
+    add_column :account_entries, :confirmed, :boolean, default: true, null: false
+    execute "UPDATE account_entries INNER JOIN deals ON deals.id = account_entries.deal_id SET account_entries.confirmed = deals.confirmed"
+    add_index  :account_entries, [:date, :daily_seq]
+    add_index  :account_entries, :confirmed
+    add_index  :account_entries, :initial_balance
+  end
+  def down
+    remove_index  :account_entries, :initial_balance
+    remove_index  :account_entries, [:date, :daily_seq]
+    remove_index  :account_entries, :confirmed
+    remove_column :account_entries, :confirmed
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,182 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20170516212531) do
+
+  create_table "account_entries", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.integer "user_id"
+    t.integer "account_id"
+    t.integer "deal_id"
+    t.integer "amount"
+    t.integer "balance"
+    t.integer "settlement_id"
+    t.integer "result_settlement_id"
+    t.boolean "initial_balance",                      default: false, null: false
+    t.date    "date",                                                 null: false
+    t.integer "daily_seq",                                            null: false
+    t.integer "linked_ex_entry_id"
+    t.integer "linked_ex_deal_id"
+    t.integer "linked_user_id"
+    t.string  "type"
+    t.boolean "linked_ex_entry_confirmed",            default: false, null: false
+    t.string  "summary",                   limit: 64, default: "",    null: false
+    t.boolean "creditor",                             default: false, null: false
+    t.integer "line_number",                          default: 0,     null: false
+    t.boolean "confirmed",                            default: true,  null: false
+    t.index ["account_id"], name: "index_account_entries_on_account_id", using: :btree
+    t.index ["confirmed"], name: "index_account_entries_on_confirmed", using: :btree
+    t.index ["date", "daily_seq"], name: "index_account_entries_on_date_and_daily_seq", using: :btree
+    t.index ["deal_id", "creditor", "line_number"], name: "index_account_entries_on_deal_id_and_creditor_and_line_number", unique: true, using: :btree
+    t.index ["deal_id"], name: "index_account_entries_on_deal_id", using: :btree
+    t.index ["initial_balance"], name: "index_account_entries_on_initial_balance", using: :btree
+    t.index ["result_settlement_id"], name: "index_account_entries_on_result_settlement_id", using: :btree
+    t.index ["settlement_id"], name: "index_account_entries_on_settlement_id", using: :btree
+    t.index ["user_id"], name: "index_account_entries_on_user_id", using: :btree
+  end
+
+  create_table "account_link_requests", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.integer  "account_id"
+    t.integer  "sender_id"
+    t.integer  "sender_ex_account_id"
+    t.datetime "created_at",           null: false
+    t.datetime "updated_at",           null: false
+    t.integer  "user_id"
+  end
+
+  create_table "account_links", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.integer  "user_id"
+    t.integer  "account_id"
+    t.integer  "target_user_id"
+    t.integer  "target_ex_account_id"
+    t.datetime "created_at",           null: false
+    t.datetime "updated_at",           null: false
+    t.index ["account_id"], name: "index_account_links_on_account_id", using: :btree
+    t.index ["target_ex_account_id"], name: "index_account_links_on_target_ex_account_id", using: :btree
+  end
+
+  create_table "accounts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.integer "user_id",                                           null: false
+    t.string  "name",                 limit: 32,                   null: false
+    t.integer "sort_key"
+    t.integer "partner_account_id"
+    t.text    "type",                 limit: 65535
+    t.string  "asset_kind"
+    t.boolean "active",                             default: true, null: false
+    t.text    "description",          limit: 65535
+    t.boolean "settlement_order_asc",               default: true, null: false
+    t.index ["partner_account_id"], name: "index_accounts_on_partner_account_id", using: :btree
+    t.index ["user_id"], name: "index_accounts_on_user_id", using: :btree
+  end
+
+  create_table "deal_patterns", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.integer  "user_id",                            null: false
+    t.string   "code",       limit: 10,                           collation: "utf8_bin"
+    t.string   "name",                  default: "", null: false
+    t.datetime "created_at",                         null: false
+    t.datetime "updated_at",                         null: false
+    t.datetime "used_at"
+    t.index ["user_id", "code"], name: "index_deal_patterns_on_user_id_and_code", unique: true, using: :btree
+  end
+
+  create_table "deals", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.string   "type",        limit: 20,                null: false
+    t.integer  "user_id",                               null: false
+    t.date     "date",                                  null: false
+    t.integer  "daily_seq",                             null: false
+    t.string   "old_summary", limit: 64, default: "",   null: false
+    t.boolean  "confirmed",              default: true, null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["user_id"], name: "index_deals_on_user_id", using: :btree
+  end
+
+  create_table "entry_patterns", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.integer "user_id",                         null: false
+    t.integer "deal_pattern_id",                 null: false
+    t.boolean "creditor",        default: false, null: false
+    t.integer "line_number",                     null: false
+    t.string  "summary",         default: "",    null: false
+    t.integer "account_id"
+    t.integer "amount"
+    t.index ["deal_pattern_id", "creditor", "line_number"], name: "creditor_line_number", unique: true, using: :btree
+  end
+
+  create_table "friend_permissions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.integer  "user_id"
+    t.integer  "target_id"
+    t.string   "type"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "friend_requests", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.integer  "user_id"
+    t.integer  "sender_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "preferences", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.integer "user_id",                                      null: false
+    t.string  "color",             limit: 32
+    t.boolean "business_use",                 default: false, null: false
+    t.boolean "use_daily_booking",            default: true,  null: false
+    t.boolean "bookkeeping_style",            default: false, null: false
+  end
+
+  create_table "sessions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.string   "session_id",               null: false
+    t.text     "data",       limit: 65535
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+    t.index ["session_id"], name: "index_sessions_on_session_id", using: :btree
+    t.index ["updated_at"], name: "index_sessions_on_updated_at", using: :btree
+  end
+
+  create_table "settlements", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.integer  "user_id"
+    t.integer  "account_id"
+    t.text     "name",                    limit: 65535
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.text     "description",             limit: 65535
+    t.integer  "submitted_settlement_id"
+    t.string   "type",                    limit: 40
+  end
+
+  create_table "single_logins", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.string   "login"
+    t.string   "crypted_password"
+    t.integer  "user_id"
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
+  end
+
+  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.string   "login",                     limit: 80, default: "", null: false
+    t.string   "email",                     limit: 60, default: "", null: false
+    t.string   "salt",                      limit: 40, default: "", null: false
+    t.string   "role",                      limit: 40
+    t.string   "activation_code",           limit: 40
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "logged_in_at"
+    t.string   "crypted_password",          limit: 40
+    t.string   "remember_token"
+    t.datetime "remember_token_expires_at"
+    t.datetime "activated_at"
+    t.string   "type",                      limit: 40
+    t.string   "password_token",            limit: 40
+    t.datetime "password_token_expires_at"
+  end
+
+end


### PR DESCRIPTION
# Overview
DealをJoinせずに計算しやすくした

# Related Issues
* https://github.com/everyleaf/kozuchi/issues/128

# Details
* account_entries に confirmed を追加
* deals をjoin しない計算系を追加（併存状態）
* 多少既存のところから使うように修正（まだまだ...）
* いろいろ index を追加
