### PR TITLE
複数明細の変更時に項目が複製される問題の修正

### DIFF
--- a/lib/deal.rb
+++ b/lib/deal.rb
@@ -16,7 +16,7 @@ module Deal
           matched_old_entries = []
           matched_new_entries = []
           old_entries.each do |old|
-            if matched_hash = attributes.detect{|new_entry_hash| old.matched_with_attributes?(new_entry_hash) }
+            if matched_hash = attributes.detect{|new_entry_hash| !matched_new_entries.include?(new_entry_hash) && old.matched_with_attributes?(new_entry_hash) }
               matched_hash[:id] = old.id.to_s # IDを付け替える
               matched_old_entries << old
               matched_new_entries << matched_hash

--- a/lib/deal.rb
+++ b/lib/deal.rb
@@ -15,14 +15,15 @@ module Deal
           # attirbutes の中と引き当てていく
           matched_old_entries = []
           matched_new_entries = []
+          not_matched_new_entries = attributes.dup
           old_entries.each do |old|
-            if matched_hash = attributes.detect{|new_entry_hash| !matched_new_entries.include?(new_entry_hash) && old.matched_with_attributes?(new_entry_hash) }
+            if matched_hash = not_matched_new_entries.detect{|new_entry_hash| old.matched_with_attributes?(new_entry_hash) }
+              not_matched_new_entries.delete_if{|entry_hash| entry_hash.equal?(matched_hash)}
               matched_hash[:id] = old.id.to_s # IDを付け替える
               matched_old_entries << old
               matched_new_entries << matched_hash
             end
           end
-          not_matched_new_entries = attributes - matched_new_entries
           not_matched_old_entries = old_entries - matched_old_entries
 
           # 引き当てられなかったhashからは :id をなくす


### PR DESCRIPTION
# Overview
- 複数明細の変更を行う際に、項目が複製され、検証エラーとなる問題を修正しました。
- 問題を生じていた条件でのテストを追加しました。

# Related Issues
- #163
- #167, #168 とも関連しているかもしれません。

# Details
複数明細の変更を行う際に、変更前の項目に金額と口座IDの組み合わせが同じ項目が複数あり、かつ変更後にも同じ項目が複数ある場合に、該当する2つ目以降の項目が複製されていました。また、項目が複製されることで合計金額が合わないため検証エラーとなっていました。

原因としては、 lib/deal.rb で定義されている Deal::AccountCareExtension#{debtor,creditor}_entries_attributes= メソッドにおいて、新規レコードではない場合に if matched_hash = ... の行で更新時には旧項目と対応する新規項目を対応付けますが、すでにマッチしたものを除外していないため、上記条件が満たされると同一の新規項目に複数回マッチしてしまい、 matched_new_entries に同一項目が複数入ることになります。
このとき、当該旧項目はマッチしているため残ることになり、一方本来対応すべき新規項目はマッチしていないため id に nil が代入されて新規項目として追加されるため両方が残り、結果として項目が複製されていました。

修正として、対応付けの際にすでにマッチした項目を除外する処理を追加しました。
また、不具合を再現するテストを作成し、修正後コードで不具合が起きないことを確認しました。

なお、対応する項目かどうかを判定しているメソッド Entry::General#matched_with_attributes? では金額と口座IDしか比較していないため summary_mode が split のときに摘要が異なっていても true を返しますが、もしこれが仕様通りでないのであれば修正の必要があります。