### PR TITLE
Travis CIに日本語フォントを追加

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: ruby
 rvm:
   - ruby-2.3.3
 
+addons:
+  apt:
+    packages:
+      - fonts-ipafont
+
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start


### PR DESCRIPTION
# Overview
Travis CIにデフォルトでは日本語フォントが入っていないため、日本語のテキストのリンク（の一部）をクリックできず、テストが失敗する問題を修正しました。

# Related Issues
#170

# Details
- 原因は Issue #170 に記載の通りでした。
  - https://qiita.com/quattro_4/items/1179a7b74e4789a48964 に同様の事例がありました。
- 日本語フォントのパッケージ `fonts-ipafont` を `.travis.yml` に追加することで解決しました。
- 日本語フォントインストール前後のスクリーンショットはそれぞれ以下の通りです。
![screenshot_on_error](https://user-images.githubusercontent.com/37732067/37980557-59e0b4ba-3226-11e8-9166-365621fc7c2d.png)
↓
![screenshot_add_japanese_font](https://user-images.githubusercontent.com/37732067/37988495-067ab012-323c-11e8-868e-5c615c69ce3a.png)
