### PR TITLE
Gemfileから重複しているパッケージを削除（timecop）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,5 +40,4 @@ group :development, :test do
   gem "pry-rails"
   gem "rspec-rails"
   gem 'timecop'
-  gem "timecop"
 end


### PR DESCRIPTION
# Overview
`gem 'timecop'`が2行続いておりBundlerの警告が出ているので1行削除しました。

# Related Issues

# Details
