### PR TITLE
口座を指定した場合の精算一覧に年表示がない問題の修正

### DIFF
--- a/app/views/settlements/_summary.html.haml
+++ b/app/views/settlements/_summary.html.haml
@@ -1,6 +1,6 @@
 - gadget ||= false
 %table.book.settlements_summary
-  - unless @settlement_summaries.target_account
+  - unless gadget
     %tr
       %th
       - @settlement_summaries.years.each do |year, months|

--- a/spec/features/settlements_spec.rb
+++ b/spec/features/settlements_spec.rb
@@ -14,5 +14,20 @@ describe "Settlements Features", type: :feature do
     end
 
     it { expect(menu_bar).to eq "すべての精算" }
+    it { expect(page.find('.book.settlements_summary')).to have_content "#{Time.zone.today.year}年" }
+    it { expect(page.find('.book.settlements_summary')).to have_content "#{Time.zone.today.month}月" }
+  end
+
+  describe "精算（口座指定）" do
+    let(:account) { accounts(:taro_card) }
+    let(:url) { "/accounts/#{account.id}/settlements/#{Time.zone.today.year}/#{Time.zone.today.month}" }
+
+    before do
+      visit url
+    end
+
+    it { expect(menu_bar).to eq "#{account.name}の精算" }
+    it { expect(page.find('.book.settlements_summary')).to have_content "#{Time.zone.today.year}年" }
+    it { expect(page.find('.book.settlements_summary')).to have_content "#{Time.zone.today.month}月" }
   end
 end


### PR DESCRIPTION
# Overview
口座を指定した場合の精算一覧に年表示がない問題を修正しました。

# Related Issues
#148

# Details
5cb7b7851a99c50a50f962b34af84aa4821310e6 での更新漏れと思われます。