### PR TITLE
仕訳帳で口座を切り替えてもタブが総合のままとなっているのを修正

### DIFF
--- a/app/views/deals/monthly.html.haml
+++ b/app/views/deals/monthly.html.haml
@@ -59,7 +59,7 @@
             = render :partial => deal_type == 'balance_deal' ? 'balance_deal_form' : 'general_deal_form'
       %ul.nav.nav-tabs.nav-justified.body_tab#monthly_deals_body_tab{style: "margin-top: 8px;"}
         %li{roll: "presentation", class: 'active'}
-          %a.body_tab_link{data: "monthly", href: "#monthly"} 総合(#{@year}年 #{@month}月)
+          %a.body_tab_link{data: "monthly", href: "#monthly"} #{@account ? @account.name : '総合'}(#{@year}年 #{@month}月)
         %li{roll: "presentation"}
           %a.body_tab_link{data: "recent", href: "#recent"} 最近の記入
       #monthly_contents


### PR DESCRIPTION
# Overview
仕訳帳で口座を切り替えてもタブが総合のままとなっているのを修正しました。

# Related Issues
なし

# Details
仕訳帳の #monthly_deals_body_tab の左側のタブの表示は本来現在選択している口座名を表示するのだと思いますが、口座の選択に関わらず「総合(xxxx年 xx月)」固定になっているのを修正しました。