### PR TITLE
円グラフの文字がずれる問題を修正

### DIFF
--- a/app/helpers/graph_helper.rb
+++ b/app/helpers/graph_helper.rb
@@ -39,7 +39,7 @@ $ (function() {
 	cg.draw(items);
 })
     EOS
-    s << %Q(<div><canvas width="400" height="200" id="#{id}"></canvas></div>).html_safe
+    s << %Q(<div style="margin: 0 auto; width: 400px;"><canvas width="400" height="200" id="#{id}"></canvas></div>).html_safe
     s
   end
   


### PR DESCRIPTION
# Overview
収支表、資産表の円グラフ中の文字がずれる問題を修正しました。

# Related Issues
なし

# Details
収支表、資産表の円グラフ中の文字がずれていました。（Firefox、Chrome、Edgeで確認しました。hosting版でもなっています。）
`div.graph`のスタイル`text-align: center`で`canvas`は幅400pxの中央寄せになっている一方、テキストは親要素の`div`が表の幅と同じになっているため、座標指定の際の原点がずれているためです。
`div`の幅を`canvas`と合わせて、中央寄せするスタイルを追加しました。（helper内でstyle属性を直書きしてしまったので、cssファイルで設定したほうが良いかもしれません。）

個人的には、凡例のマーカーとテキストが離れて少し見づらいので`text-align: left`も追加しても良いかと思います。
参考: http://html5.jp/library/sample/graph_circle/examples/sample_graph_circle_1.html

なお、最新版のhtml5.jpグラフライブラリを使えば`div`要素の幅を自動で設定してくれるため、テキストはずれないと思いますので、html5jp_graphsの方にPRしておきます。