### PR TITLE
円グラフの凡例の位置変更

### DIFF
--- a/app/helpers/graph_helper.rb
+++ b/app/helpers/graph_helper.rb
@@ -39,7 +39,7 @@ $ (function() {
 	cg.draw(items);
 })
     EOS
-    s << %Q(<div style="margin: 0 auto; width: 400px;"><canvas width="400" height="200" id="#{id}"></canvas></div>).html_safe
+    s << %Q(<div style="margin: 0 auto; width: 400px; text-align: left;"><canvas width="400" height="200" id="#{id}"></canvas></div>).html_safe
     s
   end
   


### PR DESCRIPTION
# Overview
円グラフの凡例のテキストの位置をマーカーに寄せるように変更しました。

# Related Issues
#176

# Details
#176 で提案した内容です。
前のが更新前にマージされてたので新規でPR出しましたが、もしGitHubの作法的にこうした方が良いとかあればご指摘ください。