### PR TITLE
MySQLバージョンアップに伴うSQL修正

### DIFF
--- a/app/controllers/deal_suggestions_controller.rb
+++ b/app/controllers/deal_suggestions_controller.rb
@@ -15,12 +15,9 @@ class DealSuggestionsController < ApplicationController
     @patterns = if summary_key.blank?
       []
     else
-      # TODO: AccountEntryにサマリーが移動したのでロジックを変えたい
-      recent_summaries = current_user.general_deals.recent_summaries(summary_key)
-      if account
-        recent_summaries = recent_summaries.with_account(account.id, params[:debtor] == 'true')
-      end
-      deals = Deal::General.order(id: :desc).find(recent_summaries.map(&:id))
+      recent_summaries = current_user.general_entries.recent_summaries(summary_key)
+      recent_summaries = recent_summaries.of(account.id) if account
+      deals = Deal::General.order(id: :desc).find(recent_summaries.pluck(:deal_id))
 
       patterns = current_user.deal_patterns.contains(summary_key).recent.limit(5)
       patterns = patterns.with_account(account.id, params[:debtor] == 'true') if account

--- a/app/models/deal/general.rb
+++ b/app/models/deal/general.rb
@@ -95,22 +95,7 @@ class Deal::General < Deal::Base
       creditor_entries.size > 1 ? '諸口' : creditor_entries.first.account.name
     end
   end
-
-  # 後の検索効率のため、idで妥協する
-  scope :recent_summaries, ->(keyword) {
-    select("account_entries.summary, max(deals.id) as id"
-    ).joins("inner join account_entries on account_entries.deal_id = deals.id"
-    ).group("account_entries.summary"
-    ).where("account_entries.summary like ?", "#{keyword}%"
-    ).order("deals.id desc"
-    ).limit(5)
-  }
-
-  scope :with_account, ->(account_id, debtor) {
-    # account_entries との join はされている想定
-    where("account_entries.account_id = ? and account_entries.creditor = ?", account_id, !debtor)
-  }
-
+  
   # summary の前方一致で検索する
   def self.search_by_summary(user_id, summary_key, limit, account_id = nil, debtor = true)
     begin

--- a/app/models/entry/general.rb
+++ b/app/models/entry/general.rb
@@ -12,6 +12,15 @@ class Entry::General < Entry::Base
 
   attr_writer :partner_account_name # 相手勘定名
 
+
+  scope :recent_summaries, ->(keyword) {
+    select("summary, deal_id"
+    ).group("summary, deal_id"
+    ).where("summary like ?", "#{keyword}%"
+    ).order("deal_id desc"
+    ).limit(5)
+  }
+
   def partner_account_name
     @parter_account_name ||= deal.partner_account_name_of(self)
   end

--- a/app/models/entry/general.rb
+++ b/app/models/entry/general.rb
@@ -12,7 +12,6 @@ class Entry::General < Entry::Base
 
   attr_writer :partner_account_name # 相手勘定名
 
-
   scope :recent_summaries, ->(keyword) {
     select("summary, deal_id"
     ).group("summary, deal_id"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -154,7 +154,8 @@ class User < ApplicationRecord
   has_many :general_deals, :class_name => "Deal::General", :foreign_key => "user_id"
   has_many :balance_deals, :class_name => "Deal::Balance", :foreign_key => "user_id"
 
-  has_many :entries, :class_name => "Entry::Base"
+  has_many :entries,         class_name: "Entry::Base"
+  has_many :general_entries, class_name: "Entry::General"
   
   def default_asset
     assets.first


### PR DESCRIPTION
# Overview

手元に環境を作り直したところMySQLのバージョンが8.0.12となり、サジェッション系機能でエラーが出ていたので修正。MySQL5.7以降で発生する問題と思われる。

# Related Issues

https://github.com/everyleaf/kozuchi/issues/179

# Details

GROUP BY で参照していないカラムを ORDER BY で利用しているといったもので、そもそも該当箇所は、サマリー情報をDealからEntryに移動したときに追随をサボって適当にしのいでいた部分だったのでEntryに移動させることで問題を解消した。

連携でも問題が出ているかと思ったが、ローカルでのSpec実行で全てグリーンになり、現在進めている精算関係のブランチ特有の問題のようだった。