### PR TITLE
サジェッションでの重複項目除外

### DIFF
--- a/app/controllers/deal_suggestions_controller.rb
+++ b/app/controllers/deal_suggestions_controller.rb
@@ -17,7 +17,7 @@ class DealSuggestionsController < ApplicationController
     else
       recent_summaries = current_user.general_entries.recent_summaries(summary_key)
       recent_summaries = recent_summaries.of(account.id) if account
-      deals = Deal::General.order(id: :desc).find(recent_summaries.pluck(:deal_id))
+      deals = Deal::General.order(id: :desc).find(recent_summaries.map(&:deal_id))
 
       patterns = current_user.deal_patterns.contains(summary_key).recent.limit(5)
       patterns = patterns.with_account(account.id, params[:debtor] == 'true') if account

--- a/app/models/entry/general.rb
+++ b/app/models/entry/general.rb
@@ -13,8 +13,8 @@ class Entry::General < Entry::Base
   attr_writer :partner_account_name # 相手勘定名
 
   scope :recent_summaries, ->(keyword) {
-    select("summary, deal_id"
-    ).group("summary, deal_id"
+    select("summary, max(deal_id) as deal_id"
+    ).group("summary"
     ).where("summary like ?", "#{keyword}%"
     ).order("deal_id desc"
     ).limit(5)


### PR DESCRIPTION
# Overview
サジェッションで重複した項目が出るようになったのを修正しました。

# Related Issues
なし

# Details
#180 のSQL修正で、サジェッションに全く同じ内容が複数表示されるようになりました。
`deal_id`と`summary`の組み合わせでグループにしているため、`summary`が同じでも`deal_id`が違えば別の内容とみなされてグルーピングされないためです。
意図した仕様変更ではないと思いますので、以前と同様の結果を返すように変更しました。
（`deal_id`でグルーピングする代わりに同じサマリーの中で`deal_id`の一番大きなものを返すようにしました。）