### PR TITLE
dependabot のメジャーバージョンアップ PR を抑制

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     groups:
       minor-and-patch:
         patterns: ["*"]
@@ -13,6 +16,9 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     groups:
       minor-and-patch:
         patterns: ["*"]


### PR DESCRIPTION
## Summary

dependabot が gem や GitHub Actions のメジャーバージョンアップ PR を自動作成しないように設定。

メジャーバージョンアップは段階的に手動で行うため、minor/patch のみを対象とする。