### PR TITLE
Gemfile のバージョン制約を超える依存更新を Dependabot にさせない

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: bundler
     directory: "/"
+    versioning-strategy: lockfile-only
     schedule:
       interval: monthly
     ignore:


### PR DESCRIPTION
## 概要

Dependabot の bundler 設定に `versioning-strategy: lockfile-only` を追加します。

## 背景と課題

Rails を 7.1 系に固定する意図で Gemfile に `gem 'rails', '~> 7.1.0'` を書いていたが、PR #343 で Rails 7.1.6 → 7.2.3 が自動マージされた。原因は次の通り:

- Dependabot は既定の versioning-strategy で **Gemfile の制約自体を書き換える**ため、`~> 7.1.0` というピンが効かず `~> 7.2.3` に書き換えられた。
- `dependabot.yml` の `ignore` は major のみ対象で、Rails 7.1→7.2 は semver 上 minor 扱いのため素通りした。
- auto-merge ワークフローが major 以外を自動マージするため、レビューなしでマージされた。

Gemfile のバージョン制約だけでは Dependabot を止められない、というのが要点。

## 対応

`versioning-strategy: lockfile-only` を指定し、Dependabot に Gemfile を書き換えさせず、**既存の Gemfile の制約を満たす更新だけ**を提案させる。これにより `gem 'rails', '~> 7.2.3'`（= `>= 7.2.3, < 7.3.0`）が正となり、7.2.x のパッチは流れるが 7.3 へのマイナーアップは提案されなくなる。ピンを書いていない gem の挙動は従来通り。

## トレードオフ

`automated-security-fixes` が有効なため1点注意。ピンしている gem に脆弱性が出て修正版がピン範囲外にある場合、Dependabot は Gemfile を書き換えられず自動修正 PR を作れない。その場合はアラートが残るので手動でピンを上げる必要がある。現状ピンしているのは実質 Rails のみで、他のピンなし gem のセキュリティ自動修正は従来通り動く。