### PR TITLE
認証なしで死活監視できる /up エンドポイントを追加

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,10 @@ Rails.application.routes.draw do
   # The priority is based upon order of creation:
   # first created -> highest priority.
 
+  # 死活監視用。Rails::HealthController は ApplicationController を経由しないため
+  # BASIC 認証やログインなしでアクセスできる
+  get 'up' => 'rails/health#show', as: :rails_health_check
+
   # settings
   namespace :settings do
     controller :accounts do

--- a/spec/requests/health_check_spec.rb
+++ b/spec/requests/health_check_spec.rb
@@ -1,0 +1,10 @@
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+
+describe 'ヘルスチェック', type: :request do
+  describe 'GET /up' do
+    it '200 を返す' do
+      get '/up'
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
## 概要

死活監視（ヘルスチェック）のためのエンドポイント `/up` を追加しました。

- Rails 組み込みの `Rails::HealthController` へのルーティングを追加しています。アプリが正常に起動していれば 200、起動に問題があれば 500 を返します
- `Rails::HealthController` は `ApplicationController` を継承しないため、BASIC 認証（`BASIC_AUTH_NAME` / `BASIC_AUTH_PASSWORD` を設定した構成）やログイン必須の影響を受けずにアクセスできます