### PR TITLE
今日ボタンが朝9時前に前日を表示する問題を修正

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -20,5 +20,10 @@ module Kozuchi
     config.active_support.escape_html_entities_in_json = true
     config.active_record.schema_format = :sql
     config.active_record.observers = :user_observer
+
+    # config.time_zone は framework の初期化中に消費されるため、
+    # config/initializers 以下に書いても反映されない。ここに書く必要がある
+    config.time_zone = 'Tokyo'
+    config.i18n.default_locale = 'ja'
   end
 end

--- a/config/initializers/time_zone_and_locale.rb
+++ b/config/initializers/time_zone_and_locale.rb
@@ -1,2 +1,0 @@
-Rails.application.config.time_zone = 'Tokyo'
-Rails.application.config.i18n.default_locale = 'ja'

--- a/spec/config/time_zone_and_locale_spec.rb
+++ b/spec/config/time_zone_and_locale_spec.rb
@@ -1,0 +1,10 @@
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+
+# config.time_zone は config/initializers 以下に書くと反映されないため、
+# 設定が実際に効いていることを検証する
+describe 'タイムゾーンとロケールの設定' do
+  it 'Time.zone が Tokyo、デフォルトロケールが ja になっている' do
+    expect(Time.zone.name).to eq 'Tokyo'
+    expect(I18n.default_locale).to eq :ja
+  end
+end


### PR DESCRIPTION
## 概要

サイドバーの「今日」ボタンが、日本時間の朝9時より前に押すと前日を表示する問題（#283）を修正しました。

## 原因と対応

- `config.time_zone = 'Tokyo'` が `config/initializers/time_zone_and_locale.rb` に置かれていましたが、`config.time_zone` は Rails 本体の初期化中に読み取られるため、initializer に書いても反映されず、アプリは UTC で動作していました。UTC は JST より9時間遅れのため、朝9時までは `Time.zone.today` が前日になります
- 設定を `config/application.rb` に戻し、initializer を削除しました。ロケール設定（こちらは i18n 側の仕組みにより偶然機能していました）も同じ理由で一緒に戻しています
- 設定が実際に効いていることを検証するスペックを追加しました

## 影響範囲

- 取引の日付は `date` 型カラムのため既存データへの影響はありません
- `created_at` 等のタイムスタンプの表示が UTC から JST に変わります（本来意図された動作への回復です）

Closes #283
